### PR TITLE
Add Spotify Get Album API docs

### DIFF
--- a/docs/pages/spotify/album.mdx
+++ b/docs/pages/spotify/album.mdx
@@ -237,6 +237,4 @@ _For full details on nested objects and additional fields, see the [Spotify Get 
 
 ## Notes
 
-- A valid Spotify access token is required (handled by the Recoup API backend).
-- If neither `market` nor user country are provided, content may be considered unavailable for the client.
 - The tracks object is paginated; use its `next` and `previous` URLs to navigate through track listings.

--- a/docs/pages/spotify/album.mdx
+++ b/docs/pages/spotify/album.mdx
@@ -1,0 +1,242 @@
+---
+title: Spotify Get Album API
+description: Get Spotify catalog information for a single album.
+---
+
+# Spotify Get Album API
+
+Retrieve full details for a Spotify album. This endpoint is a proxy to the official [Spotify Get Album API](https://developer.spotify.com/documentation/web-api/reference/get-an-album).
+
+## Endpoint
+
+```http
+GET https://api.recoupable.com/api/spotify/album
+```
+
+## Parameters
+
+| Name   | Type   | Required | Description |
+| ------ | ------ | -------- | ----------- |
+| id     | string | Yes      | The Spotify ID of the album. |
+| market | string | No       | An ISO 3166-1 alpha-2 country code. If provided, only content available in that market is returned. |
+
+## Request Examples
+
+:::code-group
+
+```bash [cURL]
+curl -X GET "https://api.recoupable.com/api/spotify/album?id=4aawyAB9vmqN3uQ7FjRGTy&market=ES" \
+  -H "Content-Type: application/json"
+```
+
+```python [Python]
+import requests
+
+def get_album(album_id, market=None):
+    url = "https://api.recoupable.com/api/spotify/album"
+    params = {"id": album_id}
+    if market:
+        params["market"] = market
+    response = requests.get(url, params=params)
+    response.raise_for_status()
+    return response.json()
+
+# Example usage:
+# get_album("4aawyAB9vmqN3uQ7FjRGTy", "ES")
+```
+
+```javascript [JavaScript]
+async function getAlbum(id, market) {
+  const params = new URLSearchParams({ id });
+  if (market) params.append("market", market);
+  const response = await fetch(
+    `https://api.recoupable.com/api/spotify/album?${params}`,
+    { headers: { "Content-Type": "application/json" } }
+  );
+  if (!response.ok) throw new Error("Spotify get album failed");
+  return await response.json();
+}
+```
+
+```typescript [TypeScript]
+interface SpotifyAlbum {
+  album_type: string;
+  total_tracks: number;
+  available_markets: string[];
+  external_urls: { spotify: string };
+  href: string;
+  id: string;
+  images: { url: string; height: number | null; width: number | null }[];
+  name: string;
+  release_date: string;
+  release_date_precision: string;
+  restrictions?: { reason: string };
+  type: string;
+  uri: string;
+  artists: {
+    external_urls: { spotify: string };
+    href: string;
+    id: string;
+    name: string;
+    type: string;
+    uri: string;
+  }[];
+  tracks: {
+    href: string;
+    limit: number;
+    next: string | null;
+    offset: number;
+    previous: string | null;
+    total: number;
+    items: any[];
+  };
+  copyrights: { text: string; type: string }[];
+  external_ids: { isrc?: string; ean?: string; upc?: string };
+  genres: string[];
+  label: string;
+  popularity: number;
+}
+```
+
+:::
+
+## Example Response
+
+```json filename="Response"
+{
+  "album_type": "compilation",
+  "total_tracks": 9,
+  "available_markets": ["CA", "BR", "IT"],
+  "external_urls": {
+    "spotify": "string"
+  },
+  "href": "string",
+  "id": "2up3OPMp9Tb4dAKM2erWXQ",
+  "images": [
+    {
+      "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228",
+      "height": 300,
+      "width": 300
+    }
+  ],
+  "name": "string",
+  "release_date": "1981-12",
+  "release_date_precision": "year",
+  "restrictions": {
+    "reason": "market"
+  },
+  "type": "album",
+  "uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+  "artists": [
+    {
+      "external_urls": {
+        "spotify": "string"
+      },
+      "href": "string",
+      "id": "string",
+      "name": "string",
+      "type": "artist",
+      "uri": "string"
+    }
+  ],
+  "tracks": {
+    "href": "https://api.spotify.com/v1/me/shows?offset=0&limit=20",
+    "limit": 20,
+    "next": "https://api.spotify.com/v1/me/shows?offset=1&limit=1",
+    "offset": 0,
+    "previous": "https://api.spotify.com/v1/me/shows?offset=1&limit=1",
+    "total": 4,
+    "items": [
+      {
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "string"
+            },
+            "href": "string",
+            "id": "string",
+            "name": "string",
+            "type": "artist",
+            "uri": "string"
+          }
+        ],
+        "available_markets": ["string"],
+        "disc_number": 0,
+        "duration_ms": 0,
+        "explicit": false,
+        "external_urls": {
+          "spotify": "string"
+        },
+        "href": "string",
+        "id": "string",
+        "is_playable": false,
+        "linked_from": {
+          "external_urls": {
+            "spotify": "string"
+          },
+          "href": "string",
+          "id": "string",
+          "type": "string",
+          "uri": "string"
+        },
+        "restrictions": {
+          "reason": "string"
+        },
+        "name": "string",
+        "preview_url": "string",
+        "track_number": 0,
+        "type": "string",
+        "uri": "string",
+        "is_local": false
+      }
+    ]
+  },
+  "copyrights": [
+    {
+      "text": "string",
+      "type": "string"
+    }
+  ],
+  "external_ids": {
+    "isrc": "string",
+    "ean": "string",
+    "upc": "string"
+  },
+  "genres": [],
+  "label": "string",
+  "popularity": 0
+}
+```
+
+## Response Properties
+
+| Property | Type | Description |
+| --- | --- | --- |
+| album_type | string | The type of the album. Allowed values: "album", "single", "compilation". |
+| total_tracks | integer | The number of tracks in the album. |
+| available_markets | string[] | Markets in which the album is available. |
+| external_urls | object | Known external URLs for this album. |
+| href | string | A link to the Web API endpoint providing full details of the album. |
+| id | string | The Spotify ID for the album. |
+| images | object[] | The cover art for the album in various sizes. |
+| name | string | The name of the album. |
+| release_date | string | The date the album was first released. |
+| release_date_precision | string | The precision with which `release_date` value is known. |
+| restrictions | object | Included when a content restriction is applied. |
+| type | string | The object type. Always "album". |
+| uri | string | The Spotify URI for the album. |
+| artists | object[] | The artists of the album. |
+| tracks | object | The tracks of the album. |
+| copyrights | object[] | Copyright statements of the album. |
+| external_ids | object | Known external IDs for the album. |
+| genres | string[] | Deprecated. Always empty. |
+| label | string | The label associated with the album. |
+| popularity | integer | Popularity of the album (0-100). |
+
+_For full details on nested objects and additional fields, see the [Spotify Get Album documentation](https://developer.spotify.com/documentation/web-api/reference/get-an-album)._ 
+
+## Notes
+
+- A valid Spotify access token is required (handled by the Recoup API backend).
+- If neither `market` nor user country are provided, content may be considered unavailable for the client.
+- The tracks object is paginated; use its `next` and `previous` URLs to navigate through track listings.

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -34,6 +34,10 @@ export default defineConfig({
               text: "Spotify Search API",
               link: "/spotify/search",
             },
+            {
+              text: "Spotify Get Album API",
+              link: "/spotify/album",
+            },
           ],
         },
         {

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -36,11 +36,11 @@ export default defineConfig({
           text: "Spotify",
           items: [
             {
-              text: "Spotify Search API",
+              text: "Search",
               link: "/spotify/search",
             },
             {
-              text: "Spotify Album API",
+              text: "Album",
               link: "/spotify/album",
             },
           ],

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -30,6 +30,11 @@ export default defineConfig({
               text: "Social Posts",
               link: "/social/posts",
             },
+          ],
+        },
+        {
+          text: "Spotify",
+          items: [
             {
               text: "Spotify Search API",
               link: "/spotify/search",

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -35,7 +35,7 @@ export default defineConfig({
               link: "/spotify/search",
             },
             {
-              text: "Spotify Get Album API",
+              text: "Spotify Album API",
               link: "/spotify/album",
             },
           ],


### PR DESCRIPTION
## Summary
- document Spotify Get Album API
- add nav item for Get Album in sidebar

## Testing
- `npm run build` *(fails: vocs not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new documentation page for the Spotify Get Album API, including endpoint details, parameters, example requests in multiple languages, response schema, and usage notes.
  - Updated the API Reference sidebar to include a link to the new Spotify Get Album API documentation under the "Social" section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->